### PR TITLE
Add YTPlayerView-iframe-player.html in the asset bundle

### DIFF
--- a/InlineYoutubeView.podspec
+++ b/InlineYoutubeView.podspec
@@ -22,4 +22,5 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target = '8.0'
   s.source_files = 'InlineYoutubeView/Classes/**/*'
+  s.resources = 'InlineYoutubeView/Assets.bundle'
 end

--- a/InlineYoutubeView/Assets.bundle/Assets/YTPlayerView-iframe-player.html
+++ b/InlineYoutubeView/Assets.bundle/Assets/YTPlayerView-iframe-player.html
@@ -1,0 +1,90 @@
+<!--
+     Copyright 2014 Google Inc. All rights reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+    body { margin: 0; width:100%%; height:100%%;  background-color:#000000; }
+    html { width:100%%; height:100%%; background-color:#000000; }
+
+    .embed-container iframe,
+    .embed-container object,
+    .embed-container embed {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%% !important;
+        height: 100%% !important;
+    }
+    </style>
+</head>
+<body>
+    <div class="embed-container">
+        <div id="player"></div>
+    </div>
+    <script src="https://www.youtube.com/iframe_api" onerror="window.location.href='ytplayer://onYouTubeIframeAPIFailedToLoad'"></script>
+    <script>
+    var player;
+    var error = false;
+
+    YT.ready(function() {
+        player = new YT.Player('player', %@);
+        player.setSize(window.innerWidth, window.innerHeight);
+        window.location.href = 'ytplayer://onYouTubeIframeAPIReady';
+
+        // this will transmit playTime frequently while playng
+        function getCurrentTime() {
+             var state = player.getPlayerState();
+             if (state == YT.PlayerState.PLAYING) {
+                 time = player.getCurrentTime()
+                 window.location.href = 'ytplayer://onPlayTime?data=' + time;
+             }
+        }
+        
+        window.setInterval(getCurrentTime, 500);
+             
+    });
+
+    function onReady(event) {
+        window.location.href = 'ytplayer://onReady?data=' + event.data;
+    }
+
+    function onStateChange(event) {
+        if (!error) {            
+            window.location.href = 'ytplayer://onStateChange?data=' + event.data;
+        }
+        else {
+            error = false;
+        }
+    }
+
+    function onPlaybackQualityChange(event) {
+        window.location.href = 'ytplayer://onPlaybackQualityChange?data=' + event.data;
+    }
+
+    function onPlayerError(event) {
+        if (event.data == 100) {
+            error = true;
+        }
+        window.location.href = 'ytplayer://onError?data=' + event.data;
+    }
+    
+    window.onresize = function() {
+        player.setSize(window.innerWidth, window.innerHeight);
+    }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
In our project, we replaced the official pod (not maintained anymore) by this pod to use youtube on iOS. But we could not make it work. After investigating, we found out that there are still code path in the library that requires having the file [YTPlayerView-iframe-player.html](https://github.com/youtube/youtube-ios-player-helper/blob/master/youtube-ios-player-helper/Assets.bundle/Assets/YTPlayerView-iframe-player.html) in the Assets.bundle.

In our usage, we needed to pass custom params when loading the Youtube video. Our code was like this:
```swift
let player = InlineYoutubeView(htmlUrl: "", andVideoPlayerMode: .fullScreen)
player.load(withVideoId: videoComponent.getVideoId(), playerVars: ["disablekb": 1, "rel": 0, "playsinline": 0, "showinfo": 0, "controls": 0, "modestbranding": 1])
```

This did not work even when we tried to set the `htmlUrl` param to the one in the Readme.
After investigating, we found that we needed the `YTPlayerView-iframe-player.html` for loading video that way to work.

The code path involved is precisely at line https://github.com/flipkart-incubator/ios-inline-youtube-view/blob/a45edd77143ab51291a6cc2c69b5d19ec77d536d/InlineYoutubeView/Classes/InlineYoutubeView.m#L990